### PR TITLE
Fix: Correct type for schedule_hour and schedule_minute in Settings

### DIFF
--- a/service/app/config.py
+++ b/service/app/config.py
@@ -58,8 +58,8 @@ class Settings(BaseSettings):
     # Configuración del Scheduler
     schedule_trigger: str = "cron" # "interval" o "cron"
     schedule_minutes: int | None = None # Para trigger=interval
-    schedule_hour: int | str = 21      # Para trigger=cron (UTC)
-    schedule_minute: int | str = 0     # Para trigger=cron (UTC)
+    schedule_hour: int = 21      # Para trigger=cron (UTC)
+    schedule_minute: int = 0     # Para trigger=cron (UTC)
     # schedule_second: int | str = 0 # Si APScheduler lo usa y lo necesitas    # Configuración de Uvicorn (para ejecución local y Cloud Run)
     app_host: str = "0.0.0.0"
     app_port: int = 8080  # Puerto fijo para Cloud Run


### PR DESCRIPTION
Changed the type annotation for `schedule_hour` and `schedule_minute` in the Pydantic Settings model from `int | str` to `int`.

This ensures that Pydantic correctly converts these values, loaded from environment variables (which are strings), to integers. This resolves a `ValueError` in the root endpoint (`/`) caused by attempting to use string values with an integer-specific format code (`:02d`) in an f-string when constructing the schedule information string.